### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ behaviors:
 - `:slowblink` - turns on and off slowly (about twice a second)
 - `:fastblink` - turns on and off rapidly (about 7.5 times a second)
 - `:slowwink` - mostly on, but "winks off" once every second or so
-- `:hearbeat` - a heartbeat pattern
+- `:heartbeat` - a heartbeat pattern
 
 ## Customizing states
 


### PR DESCRIPTION
Small typo in the README for heartbeat pattern.
